### PR TITLE
e policies, background validation, etc

### DIFF
--- a/async_main.lua
+++ b/async_main.lua
@@ -19,7 +19,8 @@ cmd:option('-duel', 'true', 'Use dueling network architecture (learns advantage 
 cmd:option('-gamma', 0.99, 'Discount rate γ')
 cmd:option('-epsilonStart', 1, 'Initial value of greediness ε')
 cmd:option('-epsilonEnd', 0.01, 'Final value of greediness ε') -- Tuned DDQN final greediness (1/10 that of DQN)
-cmd:option('-epsilonSteps', 1e6, 'Number of steps to linearly decay epsilonStart to epsilonEnd') -- Usually same as memory size
+-- in ER each step = minibatch of 32, in asynq 1-step-Q each step = 1 sample
+cmd:option('-epsilonSteps', 32*1e6, 'Number of steps to linearly decay epsilonStart to epsilonEnd') -- Usually same as memory size
 cmd:option('-tau', 30000, 'Steps between target net updates τ') -- Tuned DDQN target net update interval (3x that of DQN)
 cmd:option('-rewardClip', 1, 'Clips reward magnitude at rewardClip (0 to disable)')
 cmd:option('-tdClip', 1, 'Clips TD-error δ magnitude at tdClip (0 to disable)')
@@ -30,8 +31,9 @@ cmd:option('-PALpha', 0.9, 'Persistent advantage learning parameter α (0 to dis
 cmd:option('-optimiser', 'rmspropm', 'Training algorithm') -- RMSProp with momentum as found in "Generating Sequences With Recurrent Neural Networks"
 cmd:option('-eta', 0.0000625, 'Learning rate η') -- Prioritied experience replay learning rate (1/4 that of DQN; does not account for Duel as well)
 cmd:option('-momentum', 0.95, 'Gradient descent momentum')
-cmd:option('-batchSize', 5, 'Minibatch size')
-cmd:option('-steps', 5e7, 'Training iterations (steps)') -- Frame := step in ALE; Time step := consecutive frames treated atomically by the agent
+cmd:option('-batchSize', 5, 'Accumulate gradient x batchSize')
+-- in ER each step = minibatch of 32, in asynq 1-step-Q each step = 1 sample
+cmd:option('-steps', 32 * 5e7, 'Training iterations (steps)') -- Frame := step in ALE; Time step := consecutive frames treated atomically by the agent
 cmd:option('-gradClip', 10, 'Clips L2 norm of gradients at gradClip (0 to disable)')
 -- Evaluation options
 cmd:option('-progFreq', 10000, 'Interval of steps between reporting progress')

--- a/async_run.sh
+++ b/async_run.sh
@@ -30,10 +30,10 @@ fi
 
 if [ "$PAPER" == "demo" ]; then
   # Catch demo
-  th async_main.lua -async $ASYNC -eta 0.00025 -doubleQ false -duel false -optimiser adam -steps 500000 -tau 4 -epsilonSteps 10000 -valFreq 10000 -valSteps 6000 -PALpha 0 "$@"
+  th async_main.lua -async $ASYNC -eta 0.00025 -doubleQ false -duel false -optimiser adam -steps 15000000 -tau 4 -epsilonSteps 10000 -valFreq 10000 -valSteps 6000 -PALpha 0 "$@"
 elif [ "$PAPER" == "nature" ]; then
   # Nature
-  th async_main.lua -async $ASYNC -game $GAME -duel false -epsilonEnd 0.1 -tau 10000 -doubleQ false -PALpha 0 -eta 0.00025 -gradClip 0 "$@"
+  th async_main.lua -async $ASYNC -game $GAME -duel false -tau 320000 -doubleQ false -PALpha 0 -eta 0.00025 -gradClip 0 "$@"
 elif [ "$PAPER" == "doubleq" ]; then
   # Double-Q (tuned)
   th async_main.lua -async $ASYNC -game $GAME -duel false -PALpha 0 -eta 0.00025 -gradClip 0 "$@"


### PR DESCRIPTION
Async improvements:
- added validation as a background thread, no need to stop learning, eg. I learn in 11 threads (cores) and have 1 thread run the validation (could run even all the time)
- added a simple version of the diverse decaying epsilon policies from the paper (but no "periodic sampling", I'm not sure how that makes sense)
- using different manual seed per thread: I realized with the same unique manual seed in all threads, in the case of catch probably all threads are learning the same episodes, not how it should be
- added more logging of progress to see whats going on in the various threads

Some results:
- now catch converges up to 0.8 in 2 minutes
- interesting bit I also tried `ale` with `nature breakout`: with GPU ER on my 980TI this was running for hours with 0 validation scores before it started improving. With 11 async threads I got a 443 total score on the first validation that started soon after the learning started. I'll need to run this for longer and with other games as well to see if this means something (will it really keep improving), but looks promising. At least `ale` appears to work fine with this pure torch multithreaded approach at this early stage.
