### PR TITLE
sharedRmsProp and async nature params

### DIFF
--- a/AsyncAgent.lua
+++ b/AsyncAgent.lua
@@ -2,7 +2,7 @@ local AsyncModel = require 'AsyncModel'
 local CircularQueue = require 'structures/CircularQueue'
 local classic = require 'classic'
 local optim = require 'optim'
-require 'modules/rmspropm' -- Add RMSProp with momentum
+require 'modules/sharedRmsProp'
 require 'classic.torch'
 
 local AsyncAgent = classic.class('AsyncAgent')
@@ -10,7 +10,7 @@ local AsyncAgent = classic.class('AsyncAgent')
 local EPSILON_ENDS = { 0.01, 0.1, 0.5}
 local EPSILON_PROBS = { 0.4, 0.7, 1 }
 
-function AsyncAgent:_init(opt, policyNet, targetNet, theta, counters)
+function AsyncAgent:_init(opt, policyNet, targetNet, theta, counters, sharedG)
   log.info('creating AsyncAgent')
   local asyncModel = AsyncModel(opt)
   self.env, self.model = asyncModel:getEnvAndModel()
@@ -21,7 +21,8 @@ function AsyncAgent:_init(opt, policyNet, targetNet, theta, counters)
   self.optimiser = optim[opt.optimiser]
   self.optimParams = {
     learningRate = opt.eta,
-    momentum = opt.momentum
+    momentum = opt.momentum,
+    g = sharedG
   }
 
   local actionSpec = self.env:getActionSpec()

--- a/async_main.lua
+++ b/async_main.lua
@@ -28,7 +28,7 @@ cmd:option('-doubleQ', 'true', 'Use Double Q-learning')
 -- Note from Georg Ostrovski: The advantage operators and Double DQN are not entirely orthogonal as the increased action gap seems to reduce the statistical bias that leads to value over-estimation in a similar way that Double DQN does
 cmd:option('-PALpha', 0.9, 'Persistent advantage learning parameter α (0 to disable)')
 -- Training options
-cmd:option('-optimiser', 'rmspropm', 'Training algorithm') -- RMSProp with momentum as found in "Generating Sequences With Recurrent Neural Networks"
+cmd:option('-optimiser', 'sharedRmsProp', 'Training algorithm')
 cmd:option('-eta', 0.0000625, 'Learning rate η') -- Prioritied experience replay learning rate (1/4 that of DQN; does not account for Duel as well)
 cmd:option('-momentum', 0.95, 'Gradient descent momentum')
 cmd:option('-batchSize', 5, 'Accumulate gradient x batchSize')
@@ -111,6 +111,7 @@ opt.Tensor = function(...)
   return torch.Tensor(...)
 end
 
+log.info(opt)
 
 local master = AsyncMaster(opt)
 

--- a/async_run.sh
+++ b/async_run.sh
@@ -33,7 +33,7 @@ if [ "$PAPER" == "demo" ]; then
   th async_main.lua -async $ASYNC -eta 0.00025 -doubleQ false -duel false -optimiser adam -steps 15000000 -tau 4 -epsilonSteps 10000 -valFreq 10000 -valSteps 6000 -PALpha 0 "$@"
 elif [ "$PAPER" == "nature" ]; then
   # Nature
-  th async_main.lua -async $ASYNC -game $GAME -duel false -tau 320000 -doubleQ false -PALpha 0 -eta 0.00025 -gradClip 0 "$@"
+    th async_main.lua -async $ASYNC -game $GAME -duel false -tau 40000 -optimiser sharedRmsProp -epsilonSteps 4000000 -doubleQ false -PALpha 0 -eta 0.0016 -gradClip 0 "$@"
 elif [ "$PAPER" == "doubleq" ]; then
   # Double-Q (tuned)
   th async_main.lua -async $ASYNC -game $GAME -duel false -PALpha 0 -eta 0.00025 -gradClip 0 "$@"

--- a/modules/sharedRmsProp.lua
+++ b/modules/sharedRmsProp.lua
@@ -1,0 +1,29 @@
+function optim.sharedRmsProp(opfunc, x, config, state)
+  -- Get state
+  local config = config or {}
+  local state = state or config
+  local lr = config.learningRate or 1e-2
+  local momentum = config.momentum or 0.95
+  local epsilon = config.epsilon or 0.01
+
+  -- Evaluate f(x) and df/dx
+  local fx, dfdx = opfunc(x)
+
+  -- Initialise storage
+  if not state.g then
+    state.g = torch.Tensor():typeAs(x):resizeAs(dfdx):zero()
+  end
+
+  if not state.tmp then
+    state.tmp = torch.Tensor():typeAs(x):resizeAs(dfdx)
+  end
+
+  state.g:mul(momentum):addcmul(1 - momentum, dfdx, dfdx)
+  state.tmp:copy(state.g):add(epsilon):sqrt()
+
+  -- Update x = x - lr x df/dx / tmp
+  x:addcdiv(-lr, dfdx, state.tmp)
+
+  -- Return x*, f(x) before optimisation
+  return x, {fx}
+end


### PR DESCRIPTION
#### shared rmsprop

The original dqn code has rmsprop based on `g` and `gSquared` (squared momentum). The paper uses shared RmsProp optimization, so I wanted to make the existing code shared, but noticed calculating with both `g` and `gSq` cannot be made "thread safe" within the async hogwild setting as gradient updates become NaN because of concurrent updates to `g` and `gSq` (can't be fixed without locking). Then I realized the paper just uses `g` and no squared momentum and doing like that works indeed with async hogwild. Shared rmsprop now looks similar to the torch [rmsprop](https://github.com/torch/optim/blob/master/rmsprop.lua) which btw seems buggy as it adds epsilon outside the `sqrt`.
#### speed

This seems a huge issue. The figures in the paper suggest their implementation is running at ~700k frames per hour per thread. Mine runs at 125k per hour per thread. Also I was running the original per thread rmsprop and saw it was converging, but much slower than the paper, which would be explained by the processing speed difference.

This 5.5x speed difference is huge, even if their implementation is in c++, lua isn't supposed to be that slower. This must be improved as this way this async implementation is slower than running ER on GPU. I'll try speeding up the code.
#### ALE

Another issue is ALE thread safety. ALE author [says](https://github.com/mgbellemare/Arcade-Learning-Environment/issues/156#issuecomment-203380994):

> ALE is close to, but possibly not quite thread-safe.

so I'm using a patched version of xitari where I modified the static fields of one class to be instance fields, this is was the most obvious issue. I'll look if there's some other global state. Paper doesn't mention this, but they could have made more fixes. Its good at least Bellemare says "close to"...
