### PR TITLE
NStepQ working

### DIFF
--- a/A3CAgent.lua
+++ b/A3CAgent.lua
@@ -2,14 +2,18 @@ local classic = require 'classic'
 local optim = require 'optim'
 require 'modules/sharedRmsProp'
 
-local A3CAgent = classic.class('A3CAgent')
+local A3CAgent,super = classic.class('A3CAgent', 'AsyncAgent')
 
-function A3CAgent:_init(opt)
+
+function A3CAgent:_init(opt, policyNet, targetNet, theta, targetTheta, atomic, sharedG)
+  super._init(self, opt, policyNet, targetNet, theta, targetTheta, atomic, sharedG)
+  
   log.info('creating QAgent')
   local asyncModel = AsyncModel(opt)
   self.env, self.model = asyncModel:getEnvAndModel()
 
   self.id = __threadid or 1
+  self.atomic = atomic
 
   self.optimiser = optim[opt.optimiser]
   self.optimParams = {
@@ -24,30 +28,27 @@ function A3CAgent:_init(opt)
   self.m = actionSpec[3][2] - actionSpec[3][1] + 1
   self.actionOffset = 1 - actionSpec[3][1]
 
-  self.policyNet = policyNet:clone('weight', 'bias')
-  self.targetNet = targetNet:clone('weight', 'bias')
-  self.targetNet:evaluate()
+  self.policyNet_ = policyNet:clone('weight', 'bias')
 
   self.theta = theta
-  local __, gradParams = self.policyNet:parameters()
-  self.dTheta = nn.Module.flatten(gradParams)
+  __, self.dTheta = self.policyNet_:getParams()
   self.dTheta:zero()
 
   self.ale = opt.ale
 
   self.stateBuffer = CircularQueue(opt.histLen, opt.Tensor, {opt.nChannels, opt.height, opt.width})
 
-  self.gamma = opt.gamma -- ???
+  self.gamma = opt.gamma
   self.rewardClip = opt.rewardClip
   self.tdClip = opt.tdClip
   self.gradClip = opt.gradClip
 
   self.progFreq = opt.progFreq
-  self.batchSize = opt.batchSize
+  self.t_max = opt.batchSize
 
   self.Tensor = opt.Tensor
 
-  self.batchIdx = 0
+  self.T = 0
   self.target = self.Tensor(self.m)
 
   self.totalSteps = math.floor(opt.steps / opt.threads)
@@ -59,8 +60,45 @@ function A3CAgent:_init(opt)
 end
 
 
-function A3CAgent:learn(steps)
+function A3CAgent:learn(steps, from)
+  self.step = from or 0
 
+  self.stateBuffer:clear()
+  if self.ale then self.env:training() end
+
+  log.info('A3CAgent starting | steps=%d | ε=%.2f -> %.2f', steps, self.epsilon, self.epsilonEnd)
+  local reward, terminal, state = self:start()
+
+  self.states:resize(self.batchSize, unpack(state:size():totable()))
+
+  self.tic = torch.tic()
+  repeat
+    self.theta_:copy(self.theta)
+    self.batchIdx = 0
+    repeat
+      self.batchIdx = self.batchIdx + 1
+      self.states[self.batchIdx]:copy(state)
+
+      local action = self:eGreedy(state, self.policyNet_)
+      self.actions[self.batchIdx] = action
+      self.Qs[self.batchIdx]:copy(self.QCurr)
+
+      reward, terminal, state = self:takeAction(action)
+      self.rewards[self.batchIdx] = reward
+
+      self:progress(steps)
+    until terminal or self.batchIdx == self.batchSize
+
+    self:accumulateGradients(terminal, state)
+
+    if terminal then 
+      reward, terminal, state = self:start()
+    end
+
+    self:applyGradients(self.policyNet_, self.dTheta_, self.theta)
+  until self.step == steps
+
+  log.info('A3CAgent ended learning steps=%d ε=%.4f', steps, self.epsilon)
 end
 
 

--- a/A3CAgent.lua
+++ b/A3CAgent.lua
@@ -100,8 +100,6 @@ function A3CAgent:accumulateGradients(terminal, state)
     local advantage = R - self.Vs[i]
 
     self.policyTarget:zero()
-    self.policyTarget[action] = -(actionLogProbability * advantage + self.beta * entropy)
-    self.vTarget = - advantage
 
     self.policyNet_:backward(self.targets)
   end

--- a/A3CAgent.lua
+++ b/A3CAgent.lua
@@ -7,54 +7,15 @@ local A3CAgent,super = classic.class('A3CAgent', 'AsyncAgent')
 
 function A3CAgent:_init(opt, policyNet, targetNet, theta, targetTheta, atomic, sharedG)
   super._init(self, opt, policyNet, targetNet, theta, targetTheta, atomic, sharedG)
-  
-  log.info('creating QAgent')
-  local asyncModel = AsyncModel(opt)
-  self.env, self.model = asyncModel:getEnvAndModel()
 
-  self.id = __threadid or 1
-  self.atomic = atomic
-
-  self.optimiser = optim[opt.optimiser]
-  self.optimParams = {
-    learningRate = opt.eta,
-    momentum = opt.momentum,
-    g = sharedG
-  }
-
-  self.learningRateStart = opt.eta
-
-  local actionSpec = self.env:getActionSpec()
-  self.m = actionSpec[3][2] - actionSpec[3][1] + 1
-  self.actionOffset = 1 - actionSpec[3][1]
+  log.info('creating A3CAgent')
 
   self.policyNet_ = policyNet:clone('weight', 'bias')
 
-  self.theta = theta
-  __, self.dTheta = self.policyNet_:getParams()
-  self.dTheta:zero()
+  __, self.dTheta_ = self.policyNet_:getParams()
+  self.dTheta_:zero()
 
-  self.ale = opt.ale
-
-  self.stateBuffer = CircularQueue(opt.histLen, opt.Tensor, {opt.nChannels, opt.height, opt.width})
-
-  self.gamma = opt.gamma
-  self.rewardClip = opt.rewardClip
-  self.tdClip = opt.tdClip
-  self.gradClip = opt.gradClip
-
-  self.progFreq = opt.progFreq
-  self.t_max = opt.batchSize
-
-  self.Tensor = opt.Tensor
-
-  self.T = 0
   self.target = self.Tensor(self.m)
-
-  self.totalSteps = math.floor(opt.steps / opt.threads)
-
-  self.tic = 0
-  self.step = 0
 
   classic.strict(self)
 end

--- a/AsyncAgent.lua
+++ b/AsyncAgent.lua
@@ -1,0 +1,116 @@
+local AsyncModel = require 'AsyncModel'
+local CircularQueue = require 'structures/CircularQueue'
+local classic = require 'classic'
+local optim = require 'optim'
+require 'modules/sharedRmsProp'
+
+local AsyncAgent = classic.class('AsyncAgent')
+
+
+function AsyncAgent:_init(opt, policyNet, targetNet, theta, targetTheta, atomic, sharedG)
+  log.info('creating AsyncAgent')
+  local asyncModel = AsyncModel(opt)
+  self.env, self.model = asyncModel:getEnvAndModel()
+
+  self.id = __threadid or 1
+  self.atomic = atomic
+
+  self.optimiser = optim[opt.optimiser]
+  self.optimParams = {
+    learningRate = opt.eta,
+    momentum = opt.momentum,
+    g = sharedG
+  }
+
+  self.learningRateStart = opt.eta
+
+  local actionSpec = self.env:getActionSpec()
+  self.m = actionSpec[3][2] - actionSpec[3][1] + 1
+  self.actionOffset = 1 - actionSpec[3][1]
+
+  self.policyNet = policyNet:clone('weight', 'bias')
+
+  self.theta = theta
+  local __, gradParams = self.policyNet:parameters()
+  self.dTheta = nn.Module.flatten(gradParams)
+  self.dTheta:zero()
+
+  self.ale = opt.ale
+
+  self.stateBuffer = CircularQueue(opt.histLen, opt.Tensor, {opt.nChannels, opt.height, opt.width})
+
+  self.gamma = opt.gamma
+  self.rewardClip = opt.rewardClip
+  self.tdClip = opt.tdClip
+
+  self.progFreq = opt.progFreq
+  self.batchSize = opt.batchSize
+  self.gradClip = opt.gradClip
+  self.tau = opt.tau
+  self.Tensor = opt.Tensor
+
+  self.batchIdx = 0
+
+  self.totalSteps = math.floor(opt.steps / opt.threads)
+
+  self.tic = 0
+  self.step = 0
+end
+
+
+function AsyncAgent:start()
+  local reward, rawObservation, terminal = 0, self.env:start(), false
+  local observation = self.model:preprocess(rawObservation)
+  self.stateBuffer:push(observation)
+  return reward, terminal, self.stateBuffer:readAll()
+end
+
+
+function AsyncAgent:takeAction(action)
+  local reward, rawObservation, terminal = self.env:step(action - self.actionOffset)
+  if self.rewardClip > 0 then
+    reward = math.max(reward, -self.rewardClip)
+    reward = math.min(reward, self.rewardClip)
+  end
+
+  local observation = self.model:preprocess(rawObservation)
+  if terminal then
+    self.stateBuffer:pushReset(observation)
+  else
+    self.stateBuffer:push(observation)
+  end
+
+  return reward, terminal, self.stateBuffer:readAll()
+end
+
+
+function AsyncAgent:progress(steps)
+  if self.step % self.progFreq == 0 then
+    local progressPercent = 100 * self.step / steps
+    local speed = self.progFreq / torch.toc(self.tic)
+    self.tic = torch.tic()
+    log.info('AsyncAgent | step=%d | %.02f%% | speed=%d/sec | ε=%.2f -> %.2f | η=%.8f',
+      self.step, progressPercent, speed ,self.epsilon, self.epsilonEnd, self.optimParams.learningRate)
+  end
+end
+
+
+function AsyncAgent:applyGradients(net, dTheta, theta)
+  if self.gradClip > 0 then
+    net:gradParamClip(self.gradClip)
+  end
+
+  local feval = function()
+    local loss = 0 -- torch.mean(self.tdErr:clone():pow(2):mul(0.5))
+    return loss, dTheta
+  end
+
+  self.optimParams.learningRate = self.learningRateStart * (self.totalSteps - self.step) / self.totalSteps
+  self.optimiser(feval, theta, self.optimParams)
+
+  dTheta:zero()
+end
+
+
+return AsyncAgent
+

--- a/AsyncAgent.lua
+++ b/AsyncAgent.lua
@@ -84,17 +84,6 @@ function AsyncAgent:takeAction(action)
 end
 
 
-function AsyncAgent:progress(steps)
-  if self.step % self.progFreq == 0 then
-    local progressPercent = 100 * self.step / steps
-    local speed = self.progFreq / torch.toc(self.tic)
-    self.tic = torch.tic()
-    log.info('AsyncAgent | step=%d | %.02f%% | speed=%d/sec | ε=%.2f -> %.2f | η=%.8f',
-      self.step, progressPercent, speed ,self.epsilon, self.epsilonEnd, self.optimParams.learningRate)
-  end
-end
-
-
 function AsyncAgent:applyGradients(net, dTheta, theta)
   if self.gradClip > 0 then
     net:gradParamClip(self.gradClip)

--- a/AsyncAgent.lua
+++ b/AsyncAgent.lua
@@ -90,7 +90,7 @@ function AsyncAgent:applyGradients(net, dTheta, theta)
   end
 
   local feval = function()
-    local loss = 0 -- torch.mean(self.tdErr:clone():pow(2):mul(0.5))
+    local loss = 0 -- 0.5 * tdErr ^2
     return loss, dTheta
   end
 

--- a/AsyncMaster.lua
+++ b/AsyncMaster.lua
@@ -173,9 +173,9 @@ function AsyncMaster:start()
   local opt = self.opt
   local theta = self.theta
   local targetTheta = self.targetTheta
-  
+
   local validator = function()
-    require 'socket'
+    local posix = require 'posix'
     validAgent:start()
     local lastUpdate = 0
     while true do
@@ -188,7 +188,7 @@ function AsyncMaster:start()
         lastUpdate = globalStep
         validAgent:validate()
       end
-      socket.select(nil,nil,1)
+      posix.sleep(1)
     end
   end
 

--- a/AsyncModel.lua
+++ b/AsyncModel.lua
@@ -38,30 +38,8 @@ end
 function AsyncModel:createNet()
   local actionSpec = self.env:getActionSpec()
   local m = actionSpec[3][2] - actionSpec[3][1] + 1 -- Number of discrete actions
-  local net = self.model:create(m)
-
-  if self.a3c then return self:createA3C(net) end
-  return net
+  return self.model:create(m)
 end
 
-
-function AsyncModel:createA3C(convNetOnly)
-  local valueAndPolicy = nn.ConcatTable()
-
-  local valueFunction = nn.Sequential()
-  valueFunction:add(nn.Linear(convOutputSize, 1))
-  valueFunction:add(nn.ReLU(true))
-
-  local policy = nn.Sequential()
-  policy:add(nn.Linear(convOutputSize, m))
-  policy:add(nn.ReLU(true))
-  policy:add(nn.SoftMax())
-
-  valueAndPolicy:add(valueFunction)
-  valueAndPolicy:add(policy)
-
-  convNetOnly:add(valueAndPolicy)
-  return convNetOnly
-end
 
 return AsyncModel

--- a/AsyncModel.lua
+++ b/AsyncModel.lua
@@ -45,7 +45,7 @@ function AsyncModel:createNet()
 end
 
 
-function AsyncModel:createA3C(net)
+function AsyncModel:createA3C(convNetOnly)
   local valueAndPolicy = nn.ConcatTable()
 
   local valueFunction = nn.Sequential()
@@ -60,8 +60,8 @@ function AsyncModel:createA3C(net)
   valueAndPolicy:add(valueFunction)
   valueAndPolicy:add(policy)
 
-  net:add(valueAndPolicy)
-  return net, valueFunction, policy
+  convNetOnly:add(valueAndPolicy)
+  return convNetOnly
 end
 
 return AsyncModel

--- a/Model.lua
+++ b/Model.lua
@@ -119,7 +119,23 @@ function Model:create(m)
     net:add(nn.GradientRescale(1/self.bootstraps)) -- Normalise gradients by number of heads
     net:add(headConcat)
   elseif self.a3c then
-    net:add(head)
+    net:add(nn.Linear(convOutputSize, hiddenSize))
+
+    local valueAndPolicy = nn.ConcatTable()
+
+    local valueFunction = nn.Sequential()
+    valueFunction:add(nn.Linear(hiddenSize, 1))
+    valueFunction:add(nn.ReLU(true))
+
+    local policy = nn.Sequential()
+    policy:add(nn.Linear(hiddenSize, m))
+    policy:add(nn.ReLU(true))
+    policy:add(nn.SoftMax())
+
+    valueAndPolicy:add(valueFunction)
+    valueAndPolicy:add(policy)
+
+    net:add(valueAndPolicy)
   else
     -- Add head via ConcatTable (simplifies bootstrap code in agent)
     local headConcat = nn.ConcatTable()

--- a/Model.lua
+++ b/Model.lua
@@ -125,7 +125,6 @@ function Model:create(m)
 
     local valueFunction = nn.Sequential()
     valueFunction:add(nn.Linear(hiddenSize, 1))
-    valueFunction:add(nn.ReLU(true))
 
     local policy = nn.Sequential()
     policy:add(nn.Linear(hiddenSize, m))

--- a/NStepQAgent.lua
+++ b/NStepQAgent.lua
@@ -29,7 +29,6 @@ function NStepQAgent:learn(steps, from)
 
   log.info('NStepQAgent starting | steps=%d | ε=%.2f -> %.2f', steps, self.epsilon, self.epsilonEnd)
   local reward, terminal, state = self:start()
-  self.policyNet:forward(state) -- initialize buffers once with statesize
 
   self.states:resize(self.batchSize, unpack(state:size():totable()))
 

--- a/OneStepQAgent.lua
+++ b/OneStepQAgent.lua
@@ -68,10 +68,14 @@ function OneStepQAgent:accumulateGradient(state, action, state_, reward, termina
       Y = Y + self.gamma * APrimeMax
   end
 
+  if self.doubleQ then
+    self.QCurr = self.policyNet:forward(state):squeeze()
+  end
+
   local tdErr = Y - self.QCurr[action]
 
   self:accumulateGradientTdErr(state, action, tdErr, self.policyNet)
 end
 
-return OneStepQAgent
 
+return OneStepQAgent

--- a/QAgent.lua
+++ b/QAgent.lua
@@ -72,7 +72,13 @@ function QAgent:progress(steps)
       log.info('QAgent | updated targetNetwork at %d', self.atomic:get()) 
     end
   end
-  super.progress(self, steps)
+  if self.step % self.progFreq == 0 then
+    local progressPercent = 100 * self.step / steps
+    local speed = self.progFreq / torch.toc(self.tic)
+    self.tic = torch.tic()
+    log.info('AsyncAgent | step=%d | %.02f%% | speed=%d/sec | ε=%.2f -> %.2f | η=%.8f',
+      self.step, progressPercent, speed ,self.epsilon, self.epsilonEnd, self.optimParams.learningRate)
+  end
 end
 
 

--- a/QAgent.lua
+++ b/QAgent.lua
@@ -33,6 +33,8 @@ function QAgent:_init(opt, policyNet, targetNet, theta, targetTheta, atomic, sha
   self.tic = 0
   self.step = 0
 
+  self.alwaysComputeGreedyQ = not self.doubleQ
+
   self.QCurr = torch.Tensor(0)
 end
 
@@ -53,10 +55,16 @@ end
 function QAgent:eGreedy(state, net)
   self.epsilon = math.max(self.epsilonStart + (self.step - 1)*self.epsilonGrad, self.epsilonEnd)
 
-  self.QCurr = net:forward(state):squeeze()
+  if self.alwaysComputeGreedyQ then
+    self.QCurr = net:forward(state):squeeze()
+  end
 
   if torch.uniform() < self.epsilon then
     return torch.random(1,self.m)
+  end
+
+  if not self.alwaysComputeGreedyQ then
+    self.QCurr = net:forward(state):squeeze()
   end
 
   local _, maxIdx = self.QCurr:max(1)

--- a/QAgent.lua
+++ b/QAgent.lua
@@ -1,67 +1,30 @@
-local _ = require 'moses'
-local AsyncModel = require 'AsyncModel'
-local CircularQueue = require 'structures/CircularQueue'
 local classic = require 'classic'
-local optim = require 'optim'
-require 'modules/sharedRmsProp'
-require 'classic.torch'
 
-local QAgent = classic.class('QAgent')
+local QAgent, super = classic.class('QAgent', 'AsyncAgent')
 
 local EPSILON_ENDS = { 0.01, 0.1, 0.5}
 local EPSILON_PROBS = { 0.4, 0.7, 1 }
 
 
 function QAgent:_init(opt, policyNet, targetNet, theta, targetTheta, atomic, sharedG)
+  super._init(self, opt, policyNet, targetNet, theta, targetTheta, atomic, sharedG)
+  self.super = super
   log.info('creating QAgent')
-  local asyncModel = AsyncModel(opt)
-  self.env, self.model = asyncModel:getEnvAndModel()
 
-  self.id = __threadid or 1
-  self.atomic = atomic
-
-  self.optimiser = optim[opt.optimiser]
-  self.optimParams = {
-    learningRate = opt.eta,
-    momentum = opt.momentum,
-    g = sharedG
-  }
-
-  self.learningRateStart = opt.eta
-
-  local actionSpec = self.env:getActionSpec()
-  self.m = actionSpec[3][2] - actionSpec[3][1] + 1
-  self.actionOffset = 1 - actionSpec[3][1]
-
-  self.policyNet = policyNet:clone('weight', 'bias')
   self.targetNet = targetNet:clone('weight', 'bias')
   self.targetNet:evaluate()
 
-  self.theta = theta
   self.targetTheta = targetTheta
   local __, gradParams = self.policyNet:parameters()
   self.dTheta = nn.Module.flatten(gradParams)
   self.dTheta:zero()
 
-  self.ale = opt.ale
   self.doubleQ = opt.doubleQ
 
-  self.stateBuffer = CircularQueue(opt.histLen, opt.Tensor, {opt.nChannels, opt.height, opt.width})
-
-  self.gamma = opt.gamma
-  self.rewardClip = opt.rewardClip
-  self.tdClip = opt.tdClip
   self.epsilonStart = opt.epsilonStart
   self.epsilon = self.epsilonStart
   self.PALpha = opt.PALpha
 
-  self.progFreq = opt.progFreq
-  self.batchSize = opt.batchSize
-  self.gradClip = opt.gradClip
-  self.tau = opt.tau
-  self.Tensor = opt.Tensor
-
-  self.batchIdx = 0
   self.target = self.Tensor(self.m)
 
   self.totalSteps = math.floor(opt.steps / opt.threads)
@@ -101,47 +64,15 @@ function QAgent:eGreedy(state, net)
 end
 
 
-function QAgent:start()
-  local reward, rawObservation, terminal = 0, self.env:start(), false
-  local observation = self.model:preprocess(rawObservation)
-  self.stateBuffer:push(observation)
-  return reward, terminal, self.stateBuffer:readAll()
-end
-
-
-function QAgent:takeAction(action)
-  local reward, rawObservation, terminal = self.env:step(action - self.actionOffset)
-  if self.rewardClip > 0 then
-    reward = math.max(reward, -self.rewardClip)
-    reward = math.min(reward, self.rewardClip)
-  end
-
-  observation = self.model:preprocess(rawObservation)
-  if terminal then
-    self.stateBuffer:pushReset(observation)
-  else
-    self.stateBuffer:push(observation)
-  end
-
-  return reward, terminal, self.stateBuffer:readAll()
-end
-
-
 function QAgent:progress(steps)
   self.step = self.step + 1
   if self.atomic:inc() % self.tau == 0 then
     self.targetTheta:copy(self.theta)
     if self.tau>1000 then
-      log.info('QAgent | updated targetNetwork at %d', self.step) 
+      log.info('QAgent | updated targetNetwork at %d', self.atomic:get()) 
     end
   end
-  if self.step % self.progFreq == 0 then
-    local progressPercent = 100 * self.step / steps
-    local speed = self.progFreq / torch.toc(self.tic)
-    self.tic = torch.tic()
-    log.info('QAgent | step=%d | %.02f%% | speed=%d/sec | ε=%.2f -> %.2f | η=%.8f',
-      self.step, progressPercent, speed ,self.epsilon, self.epsilonEnd, self.optimParams.learningRate)
-  end
+  super.progress(self, steps)
 end
 
 
@@ -155,23 +86,6 @@ function QAgent:accumulateGradientTdErr(state, action, tdErr, net)
   self.target[action] = -tdErr
 
   net:backward(state, self.target)
-end
-
-
-function QAgent:applyGradients(net, dTheta, theta)
-  if self.gradClip > 0 then
-    net:gradParamClip(self.gradClip)
-  end
-
-  local feval = function()
-    local loss = 0 -- torch.mean(self.tdErr:clone():pow(2):mul(0.5))
-    return loss, dTheta
-  end
-
-  self.optimParams.learningRate = self.learningRateStart * (self.totalSteps - self.step) / self.totalSteps
-  self.optimiser(feval, theta, self.optimParams)
-
-  dTheta:zero()
 end
 
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,6 @@ luarocks install https://raw.githubusercontent.com/lake4790k/xitari/master/xitar
 And in addition install
 
 - tds
-- luasocket
 
 
 ## Acknowledgements

--- a/README.md
+++ b/README.md
@@ -4,11 +4,18 @@
 
 Asynchrounous version [[1]](#references) of DQN that runs on CPU multithreaded
 
-Modes supported
+Async modes supported
 
 * 1 step Q
-* ~~N step Q~~
+* N step Q
 * ~~A3C~~
+
+Q learning can be combined with these methods:
+
+* double Q learning
+* ~~PAL~~ 
+* ~~dueling~~
+* ~~deep recurrent~~
 
 This branch will be merged with the experience replay based `master` branch after refactoring unifying all the methods
 


### PR DESCRIPTION
Fixed the N step Q agent. Logic was good, just made the mistake (intended as speed optimization...) of not `forward`ing the same state before `backward`ing it which is incorrect as torch caches state from `forward` necessary for the `backward`. Catch now converges with n-step in less than 1 minute (was 2 mins with 1 step Q). Double Q also works with both, will run longer pong experiment to compare with and without.
