### PR TITLE
rlEnv parameter decoupling Atari and Catch

### DIFF
--- a/Display.lua
+++ b/Display.lua
@@ -10,7 +10,7 @@ local Display = classic.class('Display')
 function Display:_init(opt, state)
   self.opt = opt
   -- Activate display if using QT
-  self.zoom = opt.rlenv == 'rlenvs.Atari' and 1 or 4
+  self.zoom = opt.zoom
   self.window = qt and image.display({image=state, zoom=self.zoom})
 
   -- Set up recording

--- a/Display.lua
+++ b/Display.lua
@@ -10,7 +10,7 @@ local Display = classic.class('Display')
 function Display:_init(opt, state)
   self.opt = opt
   -- Activate display if using QT
-  self.zoom = opt.ale and 1 or 4
+  self.zoom = opt.rlenv == 'rlenvs.Atari' and 1 or 4
   self.window = qt and image.display({image=state, zoom=self.zoom})
 
   -- Set up recording
@@ -52,7 +52,7 @@ end
 -- Computes saliency map for display
 function Display:createSaliencyMap(state, agent)
   local screen -- Clone of state that can be adjusted
-  
+
   -- Convert Catch screen to RGB
   if self.opt.game == 'catch' then
     screen = torch.repeatTensor(state, 3, 1, 1)

--- a/Master.lua
+++ b/Master.lua
@@ -17,8 +17,8 @@ function Master:_init(opt)
   self.globals = Singleton({step = 1}) -- Initial step
 
   -- Initialise Catch or Arcade Learning Environment
-  log.info('Setting up ' .. opt.rlenv)
-  local Env = require(opt.rlenv)
+  log.info('Setting up ' .. opt.rlEnv)
+  local Env = require(opt.rlEnv)
   self.env = Env(opt)
   local stateSpec = self.env:getStateSpec()
 

--- a/Master.lua
+++ b/Master.lua
@@ -17,8 +17,8 @@ function Master:_init(opt)
   self.globals = Singleton({step = 1}) -- Initial step
 
   -- Initialise Catch or Arcade Learning Environment
-  log.info('Setting up ' .. (opt.ale and 'Arcade Learning Environment' or 'Catch'))
-  local Env = opt.ale and require 'rlenvs.Atari' or require 'rlenvs.Catch'
+  log.info('Setting up ' .. opt.rlenv)
+  local Env = require(opt.rlenv)
   self.env = Env(opt)
   local stateSpec = self.env:getStateSpec()
 
@@ -91,7 +91,7 @@ function Master:train()
   local stepStrFormat = '%0' .. (math.floor(math.log10(self.opt.steps)) + 1) .. 'd' -- String format for padding step with zeros
   for step = initStep, self.opt.steps do
     self.globals.step = step -- Pass step number to globals for use in other modules
-    
+
     -- Observe results of previous transition (r, s', terminal') and choose next action (index)
     local action = self.agent:observe(reward, state, terminal) -- As results received, learn in training mode
     if not terminal then

--- a/Model.lua
+++ b/Model.lua
@@ -27,14 +27,14 @@ function Model:_init(opt)
   self.duel = opt.duel
   self.bootstraps = opt.bootstraps
   self.recurrent = opt.recurrent
-  self.rlenv = opt.rlenv
+  self.rlEnv = opt.rlEnv
   self.async = opt.async
   self.a3c = opt.async == 'A3C'
 end
 
 -- Processes a single frame for DQN input; must not return same memory to prevent side-effects
 function Model:preprocess(observation)
-  if self.rlenv == 'rlenvs.Atari' then
+  if self.rlEnv == 'rlenvs.Atari' then
     -- Load frame
     local frame = observation:select(1, 1):float() -- Convert from CudaTensor if necessary
     -- Perform colour conversion
@@ -66,7 +66,7 @@ function Model:create(m)
     net:add(nn.Copy(nil, nil, true)) -- Needed when splitting batch x seq x input over seq for DRQN; better than nn.Contiguous
   end
   net:add(nn.View(histLen*self.nChannels, self.height, self.width)) -- Concatenate history in channel dimension
-  if self.rlenv == 'rlenvs.Atari' then
+  if self.rlEnv == 'rlenvs.Atari' then
     net:add(nn.SpatialConvolution(histLen*self.nChannels, 32, 8, 8, 4, 4, 1, 1))
     net:add(nn.ReLU(true))
     net:add(nn.SpatialConvolution(32, 64, 4, 4, 2, 2))

--- a/Setup.lua
+++ b/Setup.lua
@@ -142,6 +142,9 @@ function Setup:parseOptions(arg)
   cmd:option('-verbose', 'false', 'Log info for every episode (only in train mode)')
   cmd:option('-saliency', 'none', 'Display saliency maps (requires QT): none|normal|guided|deconvnet')
   cmd:option('-record', 'false', 'Record screen (only in eval mode)')
+  -- Environment options
+  cmd:option('-rlEnv', '', 'Environment class (Class name to be loaded)')
+  cmd:option('-zoom', '', 'Environment zoom (requires QT)')
   local opt = cmd:parse(arg)
 
   -- Process boolean options (Torch fails to accept false on the command line)
@@ -164,11 +167,11 @@ function Setup:parseOptions(arg)
   end
 
   -- Process environment options
-  if opt.rlenv == '' then
-    opt.rlenv = opt.game ~= 'catch' and 'rlenvs.Atari' or 'rlenvs.Catch'
+  if opt.rlEnv == '' then
+    opt.rlEnv = opt.game ~= 'catch' and 'rlenvs.Atari' or 'rlenvs.Catch'
   end
   if opt.zoom == '' then
-    opt.zoom = opt.rlenv == 'rlenvs.Catch' and 4 or 1
+    opt.zoom = opt.rlEnv == 'rlenvs.Catch' and 4 or 1
   end
 
   return opt

--- a/Setup.lua
+++ b/Setup.lua
@@ -164,8 +164,11 @@ function Setup:parseOptions(arg)
   end
 
   -- Process environment options
-  if not opt.rlenv or opt.rlenv == '' then
+  if opt.rlenv == '' then
     opt.rlenv = opt.game ~= 'catch' and 'rlenvs.Atari' or 'rlenvs.Catch'
+  end
+  if opt.zoom == '' then
+    opt.zoom = opt.rlenv == 'rlenvs.Catch' and 4 or 1
   end
 
   return opt

--- a/Setup.lua
+++ b/Setup.lua
@@ -163,9 +163,10 @@ function Setup:parseOptions(arg)
     opt._id = opt.game
   end
 
-  -- Set ALE flag
-  -- TODO: Make environment more independent
-  opt.ale = opt.game ~= 'catch'
+  -- Process environment options
+  if not opt.rlenv or opt.rlenv == '' then
+    opt.rlenv = opt.game ~= 'catch' and 'rlenvs.Atari' or 'rlenvs.Catch'
+  end
 
   return opt
 end

--- a/async/A3CAgent.lua
+++ b/async/A3CAgent.lua
@@ -25,7 +25,7 @@ function A3CAgent:_init(opt, policyNet, targetNet, theta, targetTheta, atomic, s
   self.states = torch.Tensor(0)
   self.beta = 0.01
 
-  if self.ale then self.env:training() end
+  self.env:training()
 
   classic.strict(self)
 end
@@ -62,7 +62,7 @@ function A3CAgent:learn(steps, from)
 
     self:accumulateGradients(terminal, state)
 
-    if terminal then 
+    if terminal then
       reward, terminal, state = self:start()
     end
 
@@ -81,7 +81,7 @@ function A3CAgent:accumulateGradients(terminal, state)
 
   for i=self.batchIdx,1,-1 do
     R = self.rewards[i] + self.gamma * R
-    
+
     local action = self.actions[i]
     local V, probability = unpack(self.policyNet_:forward(self.states[i]))
     probability:add(1e-100) -- could contain 0 -> log(0)= -inf -> theta = nans
@@ -110,4 +110,3 @@ function A3CAgent:progress(steps)
 end
 
 return A3CAgent
-

--- a/async/AsyncAgent.lua
+++ b/async/AsyncAgent.lua
@@ -35,8 +35,6 @@ function AsyncAgent:_init(opt, policyNet, targetNet, theta, targetTheta, atomic,
   self.dTheta = nn.Module.flatten(gradParams)
   self.dTheta:zero()
 
-  self.ale = opt.ale
-
   self.stateBuffer = CircularQueue(opt.recurrent and 1 or opt.histLen, opt.Tensor, {opt.nChannels, opt.height, opt.width})
 
   self.gamma = opt.gamma
@@ -102,4 +100,3 @@ end
 
 
 return AsyncAgent
-

--- a/async/AsyncModel.lua
+++ b/async/AsyncModel.lua
@@ -5,8 +5,8 @@ local AsyncModel = classic.class('AsyncModel')
 
 function AsyncModel:_init(opt)
   -- Initialise Catch or Arcade Learning Environment
-  log.info('Setting up ' .. (opt.ale and 'Arcade Learning Environment' or 'Catch'))
-  local Env = opt.ale and require 'rlenvs.Atari' or require 'rlenvs.Catch'
+  log.info('Setting up ' .. opt.rlenv)
+  local Env = require(opt.rlenv)
   self.env = Env(opt)
   local stateSpec = self.env:getStateSpec()
 

--- a/async/AsyncModel.lua
+++ b/async/AsyncModel.lua
@@ -5,8 +5,8 @@ local AsyncModel = classic.class('AsyncModel')
 
 function AsyncModel:_init(opt)
   -- Initialise Catch or Arcade Learning Environment
-  log.info('Setting up ' .. opt.rlenv)
-  local Env = require(opt.rlenv)
+  log.info('Setting up ' .. opt.rlEnv)
+  local Env = require(opt.rlEnv)
   self.env = Env(opt)
   local stateSpec = self.env:getStateSpec()
 

--- a/async/NStepQAgent.lua
+++ b/async/NStepQAgent.lua
@@ -17,7 +17,7 @@ function NStepQAgent:_init(opt, policyNet, targetNet, theta, targetTheta, atomic
   self.actions = torch.ByteTensor(self.batchSize)
   self.states = torch.Tensor(0)
 
-  if self.ale then self.env:training() end
+  self.env:training()
 
   self.alwaysComputeGreedyQ = false
 
@@ -52,7 +52,7 @@ function NStepQAgent:learn(steps, from)
 
     self:accumulateGradients(terminal, state)
 
-    if terminal then 
+    if terminal then
       reward, terminal, state = self:start()
     end
 
@@ -80,7 +80,7 @@ function NStepQAgent:accumulateGradients(terminal, state)
     R = self.rewards[i] + self.gamma * R
     local Q_i = self.policyNet_:forward(self.states[i]):squeeze()
     local tdErr = R - Q_i[self.actions[i]]
-    self:accumulateGradientTdErr(self.states[i], self.actions[i], tdErr, self.policyNet_) 
+    self:accumulateGradientTdErr(self.states[i], self.actions[i], tdErr, self.policyNet_)
   end
 end
 

--- a/async/OneStepQAgent.lua
+++ b/async/OneStepQAgent.lua
@@ -19,7 +19,7 @@ function OneStepQAgent:learn(steps, from)
   self.step = from or 0
   self.policyNet:training()
   self.stateBuffer:clear()
-  if self.ale then self.env:training() end
+  self.env:training()
 
   log.info('%s starting | steps=%d | ε=%.2f -> %.2f', self.agentName, steps, self.epsilon, self.epsilonEnd)
   local reward, terminal, state = self:start()
@@ -69,8 +69,8 @@ end
 function OneStepQAgent:accumulateGradient(state, action, state_, reward, terminal)
   local Y = reward
   if self.lstm then -- LSTM targetNet needs to see all states as well
-    self.targetNet:forward(state) 
-  end 
+    self.targetNet:forward(state)
+  end
   if not terminal then
       local QPrimes = self.targetNet:forward(state_):squeeze()
       local APrimeMax = QPrimes:max(1):squeeze()

--- a/async/ValidationAgent.lua
+++ b/async/ValidationAgent.lua
@@ -36,9 +36,7 @@ function ValidationAgent:_init(opt, theta, atomic)
   self.m = actionSpec[3][2] - actionSpec[3][1] + 1
   self.actionOffset = 1 - actionSpec[3][1]
 
-  self.ale = opt.ale
-
-  if self.ale then self.env:training() end
+  self.env:training()
 
   self.stateBuffer = CircularQueue(opt.recurrent and 1 or opt.histLen, opt.Tensor, {opt.nChannels, opt.height, opt.width})
   self.progFreq = opt.progFreq
@@ -105,7 +103,7 @@ function ValidationAgent:validate()
   if self.lstm then self.lstm:forget() end
 
   self.stateBuffer:clear()
-  if self.ale then self.env:evaluate() end
+  self.env:evaluate()
   self.policyNet_:evaluate()
 
   local valStepStrFormat = '%0' .. (math.floor(math.log10(self.valSteps)) + 1) .. 'd'
@@ -205,7 +203,7 @@ function ValidationAgent:weightsReport()
   local weightLayers = self.policyNet_:findModules('nn.SpatialConvolution')
   local fcLayers = self.policyNet_:findModules('nn.Linear')
   weightLayers = _.append(weightLayers, fcLayers)
-  
+
   -- Array of norms and maxima
   local wNorms = {}
   local wMaxima = {}
@@ -310,4 +308,3 @@ end
 
 
 return ValidationAgent
-


### PR DESCRIPTION
Went with `rlEnv` to disambiguate from `self.env` when it's an actual instance.

Added `zoom` so it can be configured independently from which environment is selected.

Seems the test on `if self.ale then self.env:training() end` isn't needed with https://github.com/Kaixhin/Atari/blob/e3d64709aec2c7f28535f82c50ec6b730e6c6b4a/Master.lua#L28-L34 adding fake `evaluate` and `training` functions.
