### PR TITLE
Use nn.Replicate in DuelAggregator

### DIFF
--- a/modules/DuelAggregator.lua
+++ b/modules/DuelAggregator.lua
@@ -2,16 +2,7 @@
 local DuelAggregator = function(m)
   local aggregator = nn.Sequential()
   local aggParallel = nn.ParallelTable()
-
-  -- Value duplicator (for each action)
-  local valDuplicator = nn.Sequential()
-  local valConcat = nn.ConcatTable()
-  for a = 1, m do
-    valConcat:add(nn.Identity())
-  end
-  valDuplicator:add(valConcat)
-  valDuplicator:add(nn.JoinTable(1, 1))
-
+  
   -- Advantage duplicator (for calculating and subtracting mean)
   local advDuplicator = nn.Sequential()
   local advConcat = nn.ConcatTable()
@@ -19,19 +10,14 @@ local DuelAggregator = function(m)
   -- Advantage mean duplicator
   local advMeanDuplicator = nn.Sequential()
   advMeanDuplicator:add(nn.Mean(1, 1))
-  local advMeanConcat = nn.ConcatTable()
-  for a = 1, m do
-    advMeanConcat:add(nn.Identity())
-  end
-  advMeanDuplicator:add(advMeanConcat)
-  advMeanDuplicator:add(nn.JoinTable(1, 1))
+  advMeanDuplicator:add(nn.Replicate(m, 2, 2))
   advConcat:add(advMeanDuplicator)
   advDuplicator:add(advConcat)
   -- Subtract mean from advantage values
   advDuplicator:add(nn.CSubTable())
   
   -- Add value and advantage duplicators
-  aggParallel:add(valDuplicator)
+  aggParallel:add(nn.Replicate(m, 2, 2))
   aggParallel:add(advDuplicator)
 
   -- Calculate Q^ = V^ + A^


### PR DESCRIPTION
I observe a 100x performance hit when using the `-duel` option in an environment with many actions. Unfortunately I cannot share the code that gives me this performance hit, but the problem lies in duplication method with ConcatTable. I have changed the code to use nn.Replicate instead, which fixes the performance problem for me.

So far I tested with `./run.sh demo`, and I can confirm it still converges.
