### PR TITLE
Correct entropy regularisation

### DIFF
--- a/async/A3CAgent.lua
+++ b/async/A3CAgent.lua
@@ -89,10 +89,16 @@ function A3CAgent:accumulateGradients(terminal, state)
 
     self.vTarget[1] = -0.5 * (R - V)
 
+    -- ∇θ logp(s) = 1/p(a) for chosen a, 0 otherwise
     self.policyTarget:zero()
-    local logProbability = torch.log(probability)
-    self.policyTarget[action] = -(R - V) / probability[action]  - self.beta * logProbability:sum()
+    -- f(s) ∇θ logp(s)
+    self.policyTarget[action] = -(R - V) / probability[action] -- Negative target for gradient descent
 
+    -- Calculate (negative of) gradient of entropy of policy (for gradient descent): -(-logp(s) - 1)
+    local gradEntropy = torch.log(probability) + 1
+    -- Add to target to improve exploration (prevent convergence to suboptimal deterministic policy)
+    self.policyTarget:add(self.beta, gradEntropy)
+    
     self.policyNet_:backward(self.states[i], self.targets)
   end
 end


### PR DESCRIPTION
**DO NOT MERGE YET**

@lake4790k I talked to someone about the entropy regularisation and they worked through the derivatives by hand and concluded that gradient for each action is independent, and therefore the sum shouldn't be used. I've tested with `demo-async-a3c` and it doesn't work with the current value of `beta`, but does learn reasonably when `beta` is reduced. The learning curve is more shallow/the agent takes longer to learn, presumably because of the increased exploration.

It's quite likely that this only helps with more complicated games where the policy is not straightforward. I'm going to try a run with Beam Rider using this and then with your solution to see what works, but we might have to ask the authors about this one.
